### PR TITLE
feat: update default version to 2.6.1

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -1,5 +1,5 @@
 ---
-loki_version: 2.6.0
+loki_version: 2.6.1
 loki_directory: /etc/loki
 loki_auth: true
 loki_store: /var/lib/loki


### PR DESCRIPTION
Loki release page: https://github.com/grafana/loki/releases/tag/v2.6.1